### PR TITLE
chore: ignore yaml check and format list

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -3,3 +3,5 @@ node_modules
 package-lock.json
 *.md
 .git
+*.yml
+*.yaml


### PR DESCRIPTION
This pull request makes a minor update to the `.prettierignore` file by adding YAML file patterns to the ignore list.

* Added `*.yml` and `*.yaml` patterns to `.prettierignore` to prevent Prettier from formatting YAML files.