### PR TITLE
chore: remove inline mermaid style directives from docs

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -354,14 +354,6 @@ graph TD
     M4 --> Safe
     M5 --> Safe
     Safe --> RO["Read-Only Git Commands<br/>log, diff, show, rev-parse,<br/>rev-list, ls-files, remote"]
-
-    style T1 fill:#ffcdd2,stroke:#c62828
-    style T2 fill:#ffcdd2,stroke:#c62828
-    style T3 fill:#ffcdd2,stroke:#c62828
-    style T4 fill:#ffcdd2,stroke:#c62828
-    style T5 fill:#ffcdd2,stroke:#c62828
-    style Safe fill:#c8e6c9,stroke:#2e7d32
-    style RO fill:#e8f5e9,stroke:#388e3c
 ```
 
 ### Why `execFile` and not `exec`
@@ -492,9 +484,6 @@ graph TD
     RegisterResources --> Connect["Connect StdioServerTransport"]
     Connect --> Running["Server running\nwaiting for JSON-RPC"]
     Running -->|"SIGINT/SIGTERM"| Shutdown["Graceful shutdown"]
-
-    style NoRepo fill:#fff3cd,stroke:#ffc107
-    style HasRepo fill:#d4edda,stroke:#28a745
 ```
 
 ### Tool Registration Sequence

--- a/README.md
+++ b/README.md
@@ -100,12 +100,6 @@ graph LR
     B -->|score| C["Scored Results<br/>normalized 0-100"]
     C -->|format| D["Formatted Output<br/>tables, bars, text"]
     D -->|wrap| E["MCP Response<br/>CallToolResult"]
-
-    style A fill:#f0f0f0,stroke:#999
-    style B fill:#e3f2fd,stroke:#1976d2
-    style C fill:#fff3e0,stroke:#f57c00
-    style D fill:#e8f5e9,stroke:#388e3c
-    style E fill:#f3e5f5,stroke:#7b1fa2
 ```
 
 ## Resources


### PR DESCRIPTION
This pull request removes custom styling from the Mermaid diagrams in both the `ARCHITECTURE.md` and `README.md` documentation files. The diagrams themselves remain unchanged, but the visual appearance will now use Mermaid's default styles.

Documentation updates:

* Removed all `style` directives from the Mermaid diagrams in `ARCHITECTURE.md`, so diagram nodes will no longer have custom colors and borders. [[1]](diffhunk://#diff-8f6366fd8e7a5fa30f7f05879999195b7cf5fa1e3d157822eb37f0e91d226cfdL357-L364) [[2]](diffhunk://#diff-8f6366fd8e7a5fa30f7f05879999195b7cf5fa1e3d157822eb37f0e91d226cfdL495-L497)
* Removed all `style` directives from the Mermaid diagram in `README.md`, reverting to default Mermaid styling for all nodes.